### PR TITLE
Call the en-dev task from reset-site task.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -81,6 +81,7 @@
         <exec command="drush --yes en cdb_dev" />
         <exec command="drush --yes en phone_number address barcode customer migrate_extras" />
         <exec command="drush --yes test-run Jenkins" />
+        <phingcall target='en-dev' />
       </else>
     </if>
   </target>


### PR DESCRIPTION
Or we run into failures on testing. 

Closes Issue #18
