### PR TITLE
Add limit to migration as a configuration.

### DIFF
--- a/all/modules/cdb/customer/address.inc
+++ b/all/modules/cdb/customer/address.inc
@@ -30,7 +30,9 @@ class AddressMigration extends BasicMigration {
     parent::__construct();
     $this->description = t('Address Migration');
 
-    $source_url = 'http://staging.website.dev.jenkinslaw.org/sites/all/modules/jenkins/cdb_access/cdbapi/migration/address.php';
+    $limit = get_cdb_migrate_limit();
+
+    $source_url = 'http://staging.website.dev.jenkinslaw.org/sites/all/modules/jenkins/cdb_access/cdbapi/migration/address.php?' . $limit;
     $fields = array(
       "id"     => "The Address id",
       "title" => "Address Blurb",

--- a/all/modules/cdb/customer/barcode.inc
+++ b/all/modules/cdb/customer/barcode.inc
@@ -37,7 +37,9 @@ class BarcodeMigration extends BasicMigration {
       'status' => 'The barcode status: 1',
     );
 
-    $source_url = 'http://staging.website.dev.jenkinslaw.org/sites/all/modules/jenkins/cdb_access/cdbapi/migration/barcode.php';
+    $limit = get_cdb_migrate_limit();
+
+    $source_url = 'http://staging.website.dev.jenkinslaw.org/sites/all/modules/jenkins/cdb_access/cdbapi/migration/barcode.php?' . $limit;
 
     $this->source = new MigrateSourceJSON($source_url, 'id', $fields,
       array('reader_class' => 'BarcodeJSONReader'));

--- a/all/modules/cdb/customer/company.inc
+++ b/all/modules/cdb/customer/company.inc
@@ -78,8 +78,9 @@ class CompanyMigration extends BasicMigration {
       'billing_contact' => 'Person ID for billing contact.',
       'mas90_name' => 'Mas90 Name.',
     );
+    $limit = get_cdb_migrate_limit();
 
-    $source_url = 'http://staging.website.dev.jenkinslaw.org/sites/all/modules/jenkins/cdb_access/cdbapi/migration/company.php?';
+    $source_url = 'http://staging.website.dev.jenkinslaw.org/sites/all/modules/jenkins/cdb_access/cdbapi/migration/company.php?' . $limit;
 
     $this->source = new MigrateSourceJSON($source_url, 'id', $fields,
       array('reader_class' => 'CompanyJSONReader'));

--- a/all/modules/cdb/customer/contact.inc
+++ b/all/modules/cdb/customer/contact.inc
@@ -29,7 +29,9 @@ class ContactMigration extends BasicMigration {
     $this->description = t('Contact Migration');
 
     $this->dependencies = array('Address','Phone');
-    $source_url = 'http://staging.website.dev.jenkinslaw.org/sites/all/modules/jenkins/cdb_access/cdbapi/migration/contact.php?increment=100000';
+    $limit = get_cdb_migrate_limit();
+
+    $source_url = 'http://staging.website.dev.jenkinslaw.org/sites/all/modules/jenkins/cdb_access/cdbapi/migration/contact.php?increment=100000+' . $limit;
     $fields = array(
       'id' => 'Cutomer Record ID.',
       'patron_type' => 'Essentially type of patron occupation (i.e. Attorney)',

--- a/all/modules/cdb/customer/customer.module
+++ b/all/modules/cdb/customer/customer.module
@@ -4,3 +4,15 @@
  * @file
  * customer.module
  */
+
+/**
+ * Return a URL limit variable for customer migration.
+ */
+function get_cdb_migrate_limit() {
+  $limit = '';
+
+  if (isset($_ENV['CDB_MIGRATE_LIMIT'])) {
+    $limit = 'limit=' . $_ENV['CDB_MIGRATE_LIMIT'];
+  }
+  return $limit;
+}

--- a/all/modules/cdb/customer/person.inc
+++ b/all/modules/cdb/customer/person.inc
@@ -28,7 +28,9 @@ class PersonMigration extends BasicMigration {
     parent::__construct();
     $this->description = t('Person Migration');
 
-    $source_url = 'http://staging.website.dev.jenkinslaw.org/sites/all/modules/jenkins/cdb_access/cdbapi/migration/customer.php';
+    $limit = get_cdb_migrate_limit();
+
+    $source_url = 'http://staging.website.dev.jenkinslaw.org/sites/all/modules/jenkins/cdb_access/cdbapi/migration/customer.php?' . $limit;
     $fields = array(
       'id' => 'Cutomer Record ID.',
       'barcode' => 'Barcode ID.',

--- a/all/modules/cdb/customer/phone.inc
+++ b/all/modules/cdb/customer/phone.inc
@@ -27,7 +27,8 @@ class PhoneMigration extends BasicMigration {
     parent::__construct();
     $this->description = t('Phone Migration');
 
-    $source_url = 'http://staging.website.dev.jenkinslaw.org/sites/all/modules/jenkins/cdb_access/cdbapi/migration/phone.php';
+    $limit = get_cdb_migrate_limit();
+    $source_url = 'http://staging.website.dev.jenkinslaw.org/sites/all/modules/jenkins/cdb_access/cdbapi/migration/phone.php?' . $limit;
 
     $fields = array(
       'id'         => "The unique identifier for this phone number record",


### PR DESCRIPTION
This change limits the migration as a configuration in order to speed up the Dev process

This only work if you set an environment variable called `CDB_MIGRATE_LIMIT`
