### PR TITLE
Person searches with one result redirect to entity page. #67

### DIFF
--- a/all/modules/cdb/person/person.module
+++ b/all/modules/cdb/person/person.module
@@ -1,17 +1,23 @@
 <?php
 /**
  * @file
- * Code for the person feature.
+ * Code for the Person feature.
  */
 
-#include_once 'person.features.inc';
-#include_once 'includes/Person.inc';
+include_once 'person.features.inc';
+/**
+ * @file
+ * Code for the person feature.
+ */
 
 /**
  * Implements hook_views_pre_render().
  */
 function person_views_pre_render(&$view) {
   if ($view->name == "person_search") {
+    if (count($view->result) == 1) {
+      drupal_goto("person/person/" . $view->result[0]->id);
+    }
     foreach ($view->result as &$result) {
       $fields = array('field_phone_number_entity', 'field_phone_entity');
       $result = _result_field_combine($result, $fields);
@@ -21,7 +27,7 @@ function person_views_pre_render(&$view) {
 }
 
 /**
- * Combines multiple fields with the same structure
+ * Combines multiple fields with the same structure.
  * @result is a view's result object
  * @fields is a simple array of the fields to combine. All fields will be merged
  * into the first listed field
@@ -33,4 +39,3 @@ function _result_field_combine($result, $fields) {
   $result->$fields[0] = call_user_func_array('array_merge', $field_values);
   return $result;
 }
-

--- a/all/modules/cdb/person/person.views_default.inc
+++ b/all/modules/cdb/person/person.views_default.inc
@@ -24,7 +24,10 @@ function person_views_default_views() {
   $handler = $view->new_display('default', 'Master', 'default');
   $handler->display->display_options['title'] = 'Person Search';
   $handler->display->display_options['use_more_always'] = FALSE;
-  $handler->display->display_options['access']['type'] = 'none';
+  $handler->display->display_options['access']['type'] = 'role';
+  $handler->display->display_options['access']['role'] = array(
+    2 => '2',
+  );
   $handler->display->display_options['cache']['type'] = 'none';
   $handler->display->display_options['query']['type'] = 'views_query';
   $handler->display->display_options['exposed_form']['type'] = 'input_required';

--- a/all/modules/cdb/person/tests/PersonSearchView.test
+++ b/all/modules/cdb/person/tests/PersonSearchView.test
@@ -7,6 +7,7 @@
 
 class PersonSearchViewTestCase extends DrupalWebTestCase {
 
+
   function setUp() {
     $this->setup = TRUE;
   }
@@ -34,6 +35,15 @@ class PersonSearchViewTestCase extends DrupalWebTestCase {
     $combine = _result_field_combine($result, array('field1', 'field2'));
     $expected = array(array("test" => "value"), (array("test" => "another_value")));
     $this->assertEqual($combine->field1, $expected, "Arbitray fields are combined as expected");
+  }
+
+  public function test_single_result_redirect() {
+    $user->name = 'admin';
+    $user->pass_raw = 'buddy';
+    $this->drupalLogin($user);
+    $this->drupalGet("person/search", array("query" => array("id" => "12")));
+    $message = "Single result redirects to entity page";
+    $this->assertPattern('|page-person-person|', $message);
   }
 
 }


### PR DESCRIPTION
This adds a redirect to the person search view such that if on ly one
person record is returned, the User is redirected to the detail entity
page for that user.

Updates person search view permissions.
Adds a test that this works.
