### PR TITLE
Generalize CRUDing alterations to CDB

### DIFF
--- a/all/modules/cdb/cdb.module
+++ b/all/modules/cdb/cdb.module
@@ -60,6 +60,30 @@ function cdb_permission() {
   return $perms;
 }
 
+/**
+ * Implements hook_menu_alter().
+ */
+function cdb_menu_alter(&$items) {
+  foreach (get_cdb_entities() as $entity) {
+    // View.
+    $items["$entity/%"]['access callback'] = 'user_access';
+    $items["$entity/%"]['access arguments'] = array("$entity view");
+    $items["$entity/%"]['page callback'] = 'cdb_view_page';
+    $items["$entity/%"]['page arguments'] = array(0, 1);
+
+    // Edit.
+    $items["$entity/%/edit"]['access callback'] = 'user_access';
+    $items["$entity/%/edit"]['access arguments'] = array("$entity edit");
+    $items["$entity/%/edit"]['page arguments'] = array(0, 1);
+    $items["$entity/%/edit"]['page callback'] = 'cdb_edit_page';
+
+    // Delete.
+    $items["$entity/%/delete"]['access callback'] = 'user_access';
+    $items["$entity/%/delete"]['access arguments'] = array("$entity delete");
+    $items["$entity/%/delete"]['page arguments'] = array(0, 1);
+    $items["$entity/%/delete"]['page callback'] = 'cdb_delete_page';
+  }
+}
 
 /**
  * Returns navigation links as nice_menus.
@@ -80,4 +104,42 @@ function _cdb_get_navigation_nice_menus() {
  */
 function get_cdb_entities() {
   return array('company', 'person', 'barcode', 'phone_number', 'address');
+}
+
+/**
+ * A wrapper for eck__entity__add().
+ */
+function cdb_add_new_form($entity) {
+  $form = eck__entity__add($entity, $entity);
+  return drupal_render($form);
+}
+
+/**
+ * Wrapper for eck__entity__view().
+ */
+function cdb_view_page($entity, $id) {
+  $cdb_entity = eck__entity__view($entity, $entity, $id);
+  $cdb_page = drupal_render($cdb_entity);
+
+  return $cdb_page;
+}
+
+/**
+ * Wrapper for eck__entity__edit().
+ */
+function cdb_edit_page($id) {
+  $cdb_entity = eck__entity__edit($entity, $entity, $id);
+  $cdb_edit = drupal_render($cdb_entity);
+
+  return $cdb_edit;
+}
+
+/**
+ * Wrapper for eck__entity__delete().
+ */
+function cdb_delete_page($id) {
+  $cdb_entity = eck__entity__delete('company', 'company', $id);
+  $cdb_delete = drupal_render($cdb_entity);
+
+  return $cdb_delete;
 }

--- a/all/modules/cdb/cdb.module
+++ b/all/modules/cdb/cdb.module
@@ -19,11 +19,15 @@ function cdb_preprocess_page(&$variable) {
  * Implements hook_entity_info_alter().
  */
 function cdb_entity_info_alter(&$entity_info) {
-
-  // Change some Company entity defaults.
-  $company =&  $entity_info['company']['bundles']['company'];
-  $company['crud']['add']['path'] = 'company/add';
-  $company['crud']['view']['path'] = 'company/%';
+  // Change some Cdb Entity defaults.
+  $cdb_entities = get_cdb_entities();
+  foreach ($cdb_entities as $entity) {
+    $cdb_entity =&  $entity_info[$entity]['bundles'][$entity];
+    $cdb_entity['crud']['add']['path'] = "$entity/add";
+    $cdb_entity['crud']['view']['path'] = "$entity/%";
+    $cdb_entity['crud']['edit']['path'] = "$entity/%/edit";
+    $cdb_entity['crud']['delete']['path'] = "$entity/%/delete";
+  }
 }
 
 

--- a/all/modules/cdb/cdb.module
+++ b/all/modules/cdb/cdb.module
@@ -23,7 +23,7 @@ function cdb_entity_info_alter(&$entity_info) {
   // Change some Company entity defaults.
   $company =&  $entity_info['company']['bundles']['company'];
   $company['crud']['add']['path'] = 'company/add';
-  $company['crud']['view']['path'] = 'company/view/%';
+  $company['crud']['view']['path'] = 'company/%';
 }
 
 

--- a/all/modules/cdb/cdb.module
+++ b/all/modules/cdb/cdb.module
@@ -30,6 +30,36 @@ function cdb_entity_info_alter(&$entity_info) {
   }
 }
 
+/**
+ * Implements hook_permission().
+ */
+function cdb_permission() {
+  $perms = array();
+  foreach (get_cdb_entities() as $entity) {
+    // Create.
+    $perms["$entity add"] = array(
+      'title' => "Add new $entity",
+      'description' => "Users with this permission may add new $entity records to the database.",
+    );
+    // Read.
+    $perms["$entity view"] = array(
+      'title' => "View $entity",
+      'description' => "Users with this permission may view records of type $entity.",
+    );
+    // Update.
+    $perms["$entity edit"] = array(
+      'title' => "Edit $entity",
+      'description' => "Users with this permission may edit records of type $entity.",
+    );
+    // Delete.
+    $perms["$entity delete"] = array(
+      'title' => "Delete $entity",
+      'description' => "Users with this permission may delete records of type $entity.",
+    );
+  }
+  return $perms;
+}
+
 
 /**
  * Returns navigation links as nice_menus.

--- a/all/modules/cdb/company/company.module
+++ b/all/modules/cdb/company/company.module
@@ -3,7 +3,6 @@
  * @file
  * Main file to hold Copany Domain specific hook code.
  */
-
 require_once 'company.features.inc';
 require_once 'includes/Company.inc';
 require_once 'includes/CompanyEntityForm.inc';
@@ -37,19 +36,6 @@ function company_permission() {
   return $perms;
 }
 
-/**
- * Implements hook_menu().
- */
-function company_menu() {
-  $items['company/add'] = array(
-    'title' => 'Add New Company',
-    'description' => 'The form for adding a new Company.',
-    'page callback' => 'company_add_new_form',
-    'access arguments' => array('company add'),
-  );
-
-  return $items;
-}
 
 /**
  * Implements hook_menu_alter().

--- a/all/modules/cdb/company/company.module
+++ b/all/modules/cdb/company/company.module
@@ -48,14 +48,32 @@ function company_menu() {
     'access arguments' => array('company add'),
   );
 
-  $items['company/view/%'] = array(
-    'title' => 'View Company',
-    'description' => 'View a Company page.',
-    'page callback' => 'company_view_page',
-    'access arguments' => array('company view'),
-    'page arguments' => array(2),
-  );
   return $items;
+}
+
+/**
+ * Implements hook_menu_alter().
+ */
+function company_menu_alter(&$items) {
+
+  // View.
+  $items['company/%']['access callback'] = 'user_access';
+  $items['company/%']['access arguments'] = array('company view');
+  $items['company/%']['page callback'] = 'company_view_page';
+  $items['company/%']['page arguments'] = array(1);
+
+  // Edit.
+  $items['company/%/edit']['access callback'] = 'user_access';
+  $items['company/%/edit']['access arguments'] = array('company edit');
+  $items['company/%/edit']['page arguments'] = array(1);
+  $items['company/%/edit']['page callback'] = 'company_edit_page';
+
+  // Delete.
+  $items['company/%/delete']['access callback'] = 'user_access';
+  $items['company/%/delete']['access arguments'] = array('company delete');
+  $items['company/%/delete']['page arguments'] = array(1);
+  $items['company/%/delete']['page callback'] = 'company_delete_page';
+
 }
 
 /**
@@ -74,4 +92,24 @@ function company_view_page($id) {
   $company_page = drupal_render($company);
 
   return $company_page;
+}
+
+/**
+ * Wrapper for eck__entity__edit().
+ */
+function company_edit_page($id) {
+  $company = eck__entity__edit('company', 'company', $id);
+  $company_edit = drupal_render($company);
+
+  return $company_edit;
+}
+
+/**
+ * Wrapper for eck__entity__delete().
+ */
+function company_delete_page($id) {
+  $company = eck__entity__delete('company', 'company', $id);
+  $company_delete = drupal_render($company);
+
+  return $company_delete;
 }

--- a/all/modules/cdb/company/company.module
+++ b/all/modules/cdb/company/company.module
@@ -19,23 +19,6 @@ function company_form_alter(&$form, &$form_state, $form_id) {
   }
 }
 
-/**
- * Implements hook_permission().
- */
-function company_permission() {
-  $perms = array(
-    'company add' => array(
-      'title' => 'Add New Company',
-      'description' => 'Users with this permission may add new Company records to the database.',
-    ),
-    'company view' => array(
-      'title' => 'View a Company',
-      'description' => 'Users with this permission may view Company records in the database.',
-    ),
-  );
-  return $perms;
-}
-
 
 /**
  * Implements hook_menu_alter().

--- a/all/modules/cdb/company/company.module
+++ b/all/modules/cdb/company/company.module
@@ -3,6 +3,7 @@
  * @file
  * Main file to hold Copany Domain specific hook code.
  */
+
 require_once 'company.features.inc';
 require_once 'includes/Company.inc';
 require_once 'includes/CompanyEntityForm.inc';
@@ -17,68 +18,4 @@ function company_form_alter(&$form, &$form_state, $form_id) {
   if ($form_id == 'views_exposed_form' && $form['#action'] == '/company/multi-search') {
     $form['company_name']['#type'] = 'textarea';
   }
-}
-
-
-/**
- * Implements hook_menu_alter().
- */
-function company_menu_alter(&$items) {
-
-  // View.
-  $items['company/%']['access callback'] = 'user_access';
-  $items['company/%']['access arguments'] = array('company view');
-  $items['company/%']['page callback'] = 'company_view_page';
-  $items['company/%']['page arguments'] = array(1);
-
-  // Edit.
-  $items['company/%/edit']['access callback'] = 'user_access';
-  $items['company/%/edit']['access arguments'] = array('company edit');
-  $items['company/%/edit']['page arguments'] = array(1);
-  $items['company/%/edit']['page callback'] = 'company_edit_page';
-
-  // Delete.
-  $items['company/%/delete']['access callback'] = 'user_access';
-  $items['company/%/delete']['access arguments'] = array('company delete');
-  $items['company/%/delete']['page arguments'] = array(1);
-  $items['company/%/delete']['page callback'] = 'company_delete_page';
-
-}
-
-/**
- * A wrapper for eck__entity__add().
- */
-function company_add_new_form() {
-  $form = eck__entity__add('company', 'company');
-  return drupal_render($form);
-}
-
-/**
- * Wrapper for eck__entity__view().
- */
-function company_view_page($id) {
-  $company = eck__entity__view('company', 'company', $id);
-  $company_page = drupal_render($company);
-
-  return $company_page;
-}
-
-/**
- * Wrapper for eck__entity__edit().
- */
-function company_edit_page($id) {
-  $company = eck__entity__edit('company', 'company', $id);
-  $company_edit = drupal_render($company);
-
-  return $company_edit;
-}
-
-/**
- * Wrapper for eck__entity__delete().
- */
-function company_delete_page($id) {
-  $company = eck__entity__delete('company', 'company', $id);
-  $company_delete = drupal_render($company);
-
-  return $company_delete;
 }

--- a/all/modules/cdb/company/tests/CompanyModule.test
+++ b/all/modules/cdb/company/tests/CompanyModule.test
@@ -33,23 +33,6 @@ class CompanyModuleTestCase extends DrupalWebTestCase {
   }
 
   /**
-   * Test company hook_menu().
-   */
-  public function testCompanyMenu() {
-    $actual = company_menu();
-    $expected['company/add'] = array(
-      'title' => 'Add New Company',
-      'description' => 'The form for adding a new Company.',
-      'page callback' => 'company_add_new_form',
-      'access arguments' => array('company add'),
-    );
-
-    $this->assertEqual($actual['company/add'], $expected['company/add'],
-      "the company/add slug is configured as expected.");
-
-  }
-
-  /**
    * Test company hook_perms().
    */
   public function testCompanyPerms() {

--- a/all/modules/cdb/company/tests/CompanyModule.test
+++ b/all/modules/cdb/company/tests/CompanyModule.test
@@ -32,18 +32,6 @@ class CompanyModuleTestCase extends DrupalWebTestCase {
   public function tearDown() {
   }
 
-  /**
-   * Test company hook_perms().
-   */
-  public function testCompanyPerms() {
-    $actual = company_permission();
-
-    $this->assertTrue(in_array('company add', array_keys($actual)),
-      "Company defines a 'company add' permission.");
-
-    $this->assertTrue(in_array('company view', array_keys($actual)),
-      "Company defines a 'company view' permission.");
-  }
 
   /**
    * Test company company_add_new_form().

--- a/all/modules/cdb/company/tests/CompanyModule.test
+++ b/all/modules/cdb/company/tests/CompanyModule.test
@@ -47,16 +47,6 @@ class CompanyModuleTestCase extends DrupalWebTestCase {
     $this->assertEqual($actual['company/add'], $expected['company/add'],
       "the company/add slug is configured as expected.");
 
-    $expected['company/view/%'] = array(
-      'title' => 'View Company',
-      'description' => 'View a Company page.',
-      'page callback' => 'company_view_page',
-      'access arguments' => array('company view'),
-      'page arguments' => array(2),
-    );
-    $this->assertEqual($actual['company/view/%'], $expected['company/view/%'],
-      "the company/view/% slug is configured as expected.");
-
   }
 
   /**

--- a/all/modules/cdb/company/tests/CompanyModule.test
+++ b/all/modules/cdb/company/tests/CompanyModule.test
@@ -32,29 +32,4 @@ class CompanyModuleTestCase extends DrupalWebTestCase {
   public function tearDown() {
   }
 
-
-  /**
-   * Test company company_add_new_form().
-   */
-  public function testCompanyAddNewForm() {
-    $actual = company_add_new_form();
-
-    $this->assertTrue((is_string($actual) && !empty($actual)),
-      "Company add should return a  non empty string.");
-  }
-
-  /**
-   * Test company view page.
-   */
-  public function testCompanyViewPage() {
-    $company = new Company();
-    $company->company_name = "[unit-test] " . time();
-    $company->save();
-    $actual = company_view_page($company->id);
-
-    $this->assertTrue((is_string($actual) && !empty($actual)),
-      "Company view page returns a non empty string.");
-
-  }
-
 }

--- a/all/modules/cdb/tests/CdbModule.test
+++ b/all/modules/cdb/tests/CdbModule.test
@@ -58,8 +58,8 @@ class CdbModuleTestCase extends DrupalWebTestCase {
     $this->assertEqual($company_actual['crud']['add']['path'], 'company/add',
       "The company entity add action path is 'company/add'");
 
-    $this->assertEqual($company_actual['crud']['view']['path'], 'company/view/%',
-      "The company entity view action path is 'company/view/%'");
+    $this->assertEqual($company_actual['crud']['view']['path'], 'company/%',
+      "The company entity view action path is 'company/%'");
   }
 
   /**

--- a/all/modules/cdb/tests/CdbModule.test
+++ b/all/modules/cdb/tests/CdbModule.test
@@ -143,4 +143,29 @@ class CdbModuleTestCase extends DrupalWebTestCase {
       "get_cdb_entities() returns the expected list of CDB defined entities.");
   }
 
+  /**
+   * Test company cdb_add_new_form().
+   */
+  public function testCdbAddNewForm() {
+    $actual = cdb_add_new_form('company');
+
+    $this->assertTrue((is_string($actual) && !empty($actual)),
+      "Company add should return a  non empty string.");
+  }
+
+  /**
+   * Test cdb view page.
+   */
+  public function testCdbViewPage() {
+    $company = new Company();
+    $company->company_name = "[unit-test] " . time();
+    $company->save();
+    $actual = cdb_view_page('company', $company->id);
+
+    $this->assertTrue((is_string($actual) && !empty($actual)),
+      "Cdb view page returns a non empty string.");
+
+  }
+
+
 }

--- a/all/modules/cdb/tests/CdbModule.test
+++ b/all/modules/cdb/tests/CdbModule.test
@@ -73,6 +73,27 @@ class CdbModuleTestCase extends DrupalWebTestCase {
   }
 
   /**
+   * Test cdb hook_perms().
+   */
+  public function testCdbPerms() {
+    $actual = cdb_permission();
+
+    foreach (get_cdb_entities() as $entity) {
+      $this->assertTrue(in_array("$entity add", array_keys($actual)),
+        "Cdb defines a '$entity add' permission.");
+
+      $this->assertTrue(in_array("$entity view", array_keys($actual)),
+        "Cdb defines a '$entity view' permission.");
+
+      $this->assertTrue(in_array("$entity edit", array_keys($actual)),
+        "Cdb defines a '$entity edit' permission.");
+
+      $this->assertTrue(in_array("$entity delete", array_keys($actual)),
+        "Cdb defines a '$entity delete' permission.");
+    }
+  }
+
+  /**
    * Test nice_menus functionality.
    */
   public function testNiceMenus() {

--- a/all/modules/cdb/tests/CdbModule.test
+++ b/all/modules/cdb/tests/CdbModule.test
@@ -52,14 +52,24 @@ class CdbModuleTestCase extends DrupalWebTestCase {
     );
 
     cdb_entity_info_alter($entity_info);
+    $cdb_entities = get_cdb_entities();
 
-    // Check company alterations.
-    $company_actual =& $entity_info['company']['bundles']['company'];
-    $this->assertEqual($company_actual['crud']['add']['path'], 'company/add',
-      "The company entity add action path is 'company/add'");
-
-    $this->assertEqual($company_actual['crud']['view']['path'], 'company/%',
-      "The company entity view action path is 'company/%'");
+    // Check correct CRUD alterations happen for all the cdb entity types.
+    foreach ($cdb_entities as $entity) {
+      $actual =& $entity_info[$entity]['bundles'][$entity];
+      // Create.
+      $this->assertEqual($actual['crud']['add']['path'], "$entity/add",
+        "The $entity entity add action path is '$entity/add'");
+      // Read.
+      $this->assertEqual($actual['crud']['view']['path'], "$entity/%",
+        "The $entity entity view action path is 'company/%'");
+      // Update.
+      $this->assertEqual($actual['crud']['edit']['path'], "$entity/%/edit",
+        "The $entity entity edit action path is '$entity/edit'");
+      // Delete.
+      $this->assertEqual($actual['crud']['delete']['path'], "$entity/%/delete",
+        "The $entity entity delete action path is '$entity/%/delete'");
+    }
   }
 
   /**


### PR DESCRIPTION
This change alters the code so that going to company/%/edit will edit a company user.

Also we generalize the CRUDing including permission creations to be handled directly from CDB.  This minimizes duplication of effort and leaves the individual entity module for changes specific to that entity.
